### PR TITLE
Prepare for release 2.6.1-v4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	kmodules.xyz/client-go v0.0.0-20220427165208-36281a681909
 	kmodules.xyz/custom-resources v0.0.0-20220422215041-237eae1d7ddd
 	kmodules.xyz/offshoot-api v0.0.0-20220420055916-fefb02c26514
-	stash.appscode.dev/apimachinery v0.20.0
+	stash.appscode.dev/apimachinery v0.20.1
 
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1125,5 +1125,5 @@ sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
-stash.appscode.dev/apimachinery v0.20.0 h1:JxBT94F/bfV6hkc8PxYoNOFiNeXa8YRLBp1hAX2NDz0=
-stash.appscode.dev/apimachinery v0.20.0/go.mod h1:HyYlJ56VT8QgUM7NPCMrRRr/9e+eltUHGtd7GBXUCJo=
+stash.appscode.dev/apimachinery v0.20.1 h1:pWmqoGydibXTbwFGesMdVulxPGE/J3gdSGY/9E6LOh0=
+stash.appscode.dev/apimachinery v0.20.1/go.mod h1:HyYlJ56VT8QgUM7NPCMrRRr/9e+eltUHGtd7GBXUCJo=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -623,7 +623,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.20.0
+# stash.appscode.dev/apimachinery v0.20.1
 ## explicit; go 1.17
 stash.appscode.dev/apimachinery/apis/repositories
 stash.appscode.dev/apimachinery/apis/repositories/v1alpha1


### PR DESCRIPTION
ProductLine: Stash
Release: v2022.05.18
Release-tracker: https://github.com/stashed/CHANGELOG/pull/48
Signed-off-by: 1gtm <1gtm@appscode.com>